### PR TITLE
Fix: cannot find function `on_tray_event` in crate `tauri_plugin_positioner`

### DIFF
--- a/plugins/positioner/README.md
+++ b/plugins/positioner/README.md
@@ -20,9 +20,9 @@ Install the Core plugin by adding the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-tauri-plugin-positioner = "1.0"
+tauri-plugin-positioner = { version = "1.0", features = ["system-tray"] }
 # or through git
-tauri-plugin-positioner = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
+tauri-plugin-positioner = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev", features = ["system-tray"]  }
 ```
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:


### PR DESCRIPTION
Updated docs to reflect necessity for system-tray feature for `on_tray_event`.